### PR TITLE
Resolve #34

### DIFF
--- a/php/function_validation.php
+++ b/php/function_validation.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Copyright 2022 California Institute of Technology
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @file Validates function names passed from http clients
+ *
+ * Creation Date: 2022-01-05
+ *
+ */
+
+// 🤔 TODO: This is a list of all functions defined in this application. It's still probably *too*
+// permissive. Instead, we should check to see which are actually generated through HTML templates
+// and JavaScript `backendCall` functions and narrow it down. Alas, as Morpheus once said, "Time is
+// always against us."
+$validFunctions = array(
+    "addCustomNodes",
+    "addDDAttributeNode",
+    "addDDClassNode",
+    "addIngestLDDNode",
+    "addNode",
+    "addNodeLocal",
+    "addNodeValue",
+    "addNodeValueLocal",
+    "addNodeWithComment",
+    "addRootAttrs",
+    "checkForDuplicateUser",
+    "checkIfLabelInUse",
+    "deleteLabel",
+    "fetchLabelXML",
+    "formatDoc",
+    "getIngestLDDToolXML",
+    "getLabelInfo",
+    "getLabelName",
+    "getLabelShareSettings",
+    "getLabelXML",
+    "getMissionSpecificsData",
+    "getMissionSpecificsHeaderData",
+    "getNode",
+    "getNodeLocal",
+    "getProgressData",
+    "getRawProgressData",
+    "getSampleLabelXML",
+    "getSessionLabelID",
+    "getSpecifiedLabelXML",
+    "getUserName",
+    "getUsersListing",
+    "getXMLStringToImport",
+    "handleData",
+    "handlePath",
+    "insertUser",
+    "isNaN",
+    "isNonDefaultNamespace",
+    "prependDisciplineRootNode",
+    "previewIngestLDDToolTemplate",
+    "previewLabelTemplate",
+    "readInXML",
+    "recursivelyAddDDAttributeNode",
+    "recursivelyAddDDClassNode",
+    "removeAllChildNodes",
+    "removeClass",
+    "removeNode",
+    "removeRootAttrs",
+    "resetPassword",
+    "sanitizeInput",
+    "sendLinkToResetPassword",
+    "shareLabelWithUser",
+    "stopSharingLabelWithUser",
+    "storeMissionSpecificsData",
+    "storeNewLabel",
+    "storeProgressData",
+    "storeProgressDataLocal",
+    "storeXML",
+    "storeXMLToANewLabel",
+    "testUpdateLabelXML",
+    "updateIngestLddXML",
+    "updateLabelXML",
+    "updateNodeValue",
+    "updateNodeValueLocal",
+    "validate",
+    "verifyUser",
+);
+
+function validateFunction($name) {
+    global $validFunctions;
+    if (in_array($name, $validFunctions)) return;
+    echo "🚨 Attempted call of function «" . $name . "»; not in valid list";
+    // 🤔 TODO: For future bullet-proofing, we could go farther and check args too.
+    exit(-1);
+}

--- a/php/interact_db.php
+++ b/php/interact_db.php
@@ -29,6 +29,7 @@
 require_once('../thirdparty/php/PasswordHash.php');
 require("configuration.php");
 include_once("PlaidSessionHandler.php");
+require_once("function_validation.php");
 $MAX_FILE_SIZE = 4 * 1024 * 1024;    //  4 MB
 $XML_FILE_TYPE = "text/xml";
 $XML_FILE_EXTENSION = "xml";
@@ -55,9 +56,8 @@ try{
     );
 
     if(isset($_POST['function'])){
-        # 😦 This seems remarkably unsafe!
+        validateFunction($_POST['function']);
         call_user_func($_POST['function'], $_POST);
-        # I would never allow a function to be called via a name passed over http!
     }
 }
 catch(\PDOException $ex){

--- a/php/xml_mutator.php
+++ b/php/xml_mutator.php
@@ -25,7 +25,9 @@
  * @author Stirling Algermissen
  */
 require_once("interact_db.php");
+require_once("function_validation.php");
 if(isset($_POST['Function'])){
+    validateFunction($_POST['Function']);
     $DOC = readInXML(getLabelXML());
     call_user_func($_POST['Function'], $_POST['Data']);
 }

--- a/php/xml_validator.php
+++ b/php/xml_validator.php
@@ -25,10 +25,12 @@
  */
 
 require_once("interact_db.php");
+require_once("function_validation.php");
 // Load the XSD schema from the PSA NASA site
 $schema = "https://pds.jpl.nasa.gov/pds4/schema/develop/pds/PDS4_PDS_1700.xsd";
 
 if(isset($_POST['Function'])){
+    validateFunction($_POST['Function']);
     $doc = new DOMDocument();
     $doc->loadXML(getLabelXML());
     call_user_func($_POST['Function'], $_POST['Data']);


### PR DESCRIPTION
## 🗒️ Summary

Merge this—if you dare—to resolve #34. This checks all http client function invocations against a list of valid names and aborts if the name isn't on the list. Think of it as a bouncer at a club designed to allow only the in-crowd in—except it's a [PHP](https://eev.ee/blog/2012/04/09/php-a-fractal-of-bad-design/) club and so it's a pretty dingy place anyway 😝

## ⚙️ Test Data and/or Report

```console
$ cd /tmp
$ python3 -m venv venv
$ cd venv
$ bin/pip install --quiet --upgrade setuptools pip
$ bin/pip install --quiet selenium webdriver_manager
$ curl --silent --location https://raw.githubusercontent.com/NASA-PDS/PLAID/main/tests/create_context_label_test.py | sed -e 's/Eyasu.T.Haile@jpl.nasa.gov/kelly@jpl.nasa.gov/' -e 's/pass/x/' > run.py
$ bin/python run.py
…
$ echo \U+1F389
🎉
```

## ♻️ Related Issues

- #34 
