### PR TITLE
Resolve #32

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,24 +7,22 @@
 # Base Image
 # ----------
 #
-# This is a PHP app, so we start with a PHP image, in this case PHP 5.6 based on Debian Linux 8,
-# code named "jessie".
-#
-# ⚠️ Note that Debian "jessie" reached end-of-life on 2018-06-17 and end long-term support on 
-# 2020-06-30. We really should look to use a more recent Debian Linux, such as `8.1.1-apache-bullseye`.
-#
-# ⚠️ PHP 5.6 reached end-of-life on 2019-01-01 and has no long-term support. It has received no
-# security patches 3 years. Upgrading to `8.1.1-apache-bullseye` or later is strongly recommended.
+# This is a PHP app, so we start with a PHP image, in this case PHP 7.4.27 based on Debian Linux 11,
+# code named "bullseye". Upgrading to PHP 8.1.1 would be even better, but there are a number of XML
+# parsing issues in that version that we do not, at present, have time to address.
 
-FROM php:5.6-apache-jessie
+FROM php:7.4.27-apache-bullseye
 
 
 # Dependencies
 # ------------
 #
-# We need sSMTP to send mail and the MySQL PDO extensions for PHP. 
+# We need sSMTP to send mail and the MySQL PDO extensions for PHP. During development, you might want to
+# change the `php.ini-production` to `php.ini-development` to enable Zend assertions, memory statistics,
+# start error logging, all reporting enabled, and deprecation warnings.
 
 RUN : &&\
+    mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" &&\
     apt-get update --quiet &&\
     apt-get install --quiet --yes ssmtp &&\
     docker-php-ext-install mysqli pdo pdo_mysql &&\

--- a/index.php
+++ b/index.php
@@ -1,3 +1,7 @@
+<?php
+include_once("php/PlaidSessionHandler.php");
+$session_handler = new PlaidSessionHandler();
+?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -17,8 +21,6 @@
     <form class="form-login" action="php/interact_db.php" method="post">
         <h2 class="form-login-heading">PDS Label Assistant for Interactive Design (PLAID)</h2>
         <?php
-        include_once("php/PlaidSessionHandler.php");
-        $session_handler = new PlaidSessionHandler();
         //  Enable the use of Session variables
         // session_start();
         //  IF the error code is not empty

--- a/php/DbSessionHandler.php
+++ b/php/DbSessionHandler.php
@@ -137,6 +137,7 @@ SQL
         if ($rec = $sth->fetch()) {
             return $rec['data'];
         }
+        error_log('#### 😢 We were unable to read a session from the database');
         return '';
     }
 

--- a/php/PlaidSessionHandler.php
+++ b/php/PlaidSessionHandler.php
@@ -1,6 +1,6 @@
 <?php
 require('DbSessionHandler.php');
-require("configuration.php");
+require_once("configuration.php");
 
 
 

--- a/php/reset_password.php
+++ b/php/reset_password.php
@@ -21,7 +21,7 @@
          * Date: 5/8/2017
          * Time: 12:25 PM
          */
-        require("configuration.php");
+        require_once("configuration.php");
         include_once("PlaidSessionHandler.php");
         $session_handler = new PlaidSessionHandler();
         try{

--- a/php/table_upload.php
+++ b/php/table_upload.php
@@ -19,7 +19,7 @@
 
 <?php
 
-require("configuration.php");
+require_once("configuration.php");
 require("interact_db.php");
 require("xml_mutator.php");
 

--- a/php/verify_email_address.php
+++ b/php/verify_email_address.php
@@ -22,7 +22,7 @@
      * Date: 5/4/2017
      * Time: 4:20 PM
      */
-    require("configuration.php");
+    require_once("configuration.php");
     include_once("PlaidSessionHandler.php");
     $session_handler = new PlaidSessionHandler();
     try{

--- a/thirdparty/php/PasswordHash.php
+++ b/thirdparty/php/PasswordHash.php
@@ -30,7 +30,7 @@ class PasswordHash {
 	var $portable_hashes;
 	var $random_state;
 
-	function PasswordHash($iteration_count_log2, $portable_hashes)
+	function __construct($iteration_count_log2, $portable_hashes)
 	{
 		$this->itoa64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 


### PR DESCRIPTION
## 🗒️ Summary

Merge this—if you dare—to resolve #32. This upgrades PHP from 5.6 to 7.4.27 which, as of this writing, is considered safe. Note that 8.1 is out, however there were an even higher number of issues trying to jump all the way to it.

## ⚙️ Test Data and/or Report
```console
$ cd /tmp
$ python3 -m venv venv
$ cd venv
$ bin/pip install --quiet --upgrade setuptools pip
$ bin/pip install --quiet selenium webdriver_manager
$ curl --silent --location https://raw.githubusercontent.com/NASA-PDS/PLAID/main/tests/create_context_label_test.py | sed -e 's/Eyasu.T.Haile@jpl.nasa.gov/kelly@jpl.nasa.gov/' -e 's/pass/x/' > run.py
$ bin/python run.py
…
$ echo \U+1F389
🎉
```

## ♻️ Related Issues

- #32 
